### PR TITLE
Adding quickstart notebook for NOAA GFS

### DIFF
--- a/notebooks/noaa-gfs/noaa_gfs_quickstart.ipynb
+++ b/notebooks/noaa-gfs/noaa_gfs_quickstart.ipynb
@@ -1,0 +1,387 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c037ca4d",
+   "metadata": {},
+   "source": [
+    "# NOAA Global Forecast System (GFS) quickstart notebook on AWS\n",
+    "This quickstart notebook demonstrates how to work with data from the NOAA Global Forecast System (GFS) hosted on the [Registry of Open Data on AWS](https://registry.opendata.aws/noaa-gfs-bdp-pds/). The Global Forecast System (GFS) is a weather forecast model produced by the National Centers for Environmental Prediction (NCEP).  \n",
+    "This quickstart notebook covers\n",
+    "1. Data Access - how to list and download data from the Registry of Open Data on AWS\n",
+    "2. Data Inspecting - how to inspect the data by printing the variables, etc.\n",
+    "3. Data Preprocessing - convert longitude, temperature from K to °C, etc. Only keep data from a specific area. Export as Parquet.\n",
+    "\n",
+    "This notebook is designed to run in [Amazon SageMaker Studio](https://aws.amazon.com/sagemaker-ai/studio/). You can also run it in [SageMaker Studio Lab](https://studiolab.sagemaker.aws/) if you don't have an AWS account."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c38ba27f",
+   "metadata": {},
+   "source": [
+    "## Dependencies installation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9495c2ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pip install --quiet cfgrib xarray boto3 pandas pyarrow plotly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d9c1cf47",
+   "metadata": {},
+   "source": [
+    "## 1. Data Access\n",
+    "\n",
+    "NOAA GFS data is made available by the [Registry of Open Data on AWS](https://registry.opendata.aws/noaa-gfs-bdp-pds/) in a public S3 bucket.  \n",
+    "Let's list all objects for a given date and forecast cycle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f216094",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "from botocore import UNSIGNED\n",
+    "from botocore.config import Config\n",
+    "\n",
+    "s3 = boto3.client('s3', config=Config(signature_version=UNSIGNED))\n",
+    "\n",
+    "# --- Configuration ---\n",
+    "GFS_BUCKET_NAME = \"noaa-gfs-bdp-pds\"\n",
+    "FORECAST_DATE = \"20250708\"\n",
+    "# Forecasts are made available four times per day, every 6 hours starting at midnight UTC.\n",
+    "FORECAST_CYCLE = \"00\"\n",
+    "# GFS couples four separate models (atmosphere, ocean model, land/soil model, and sea ice)\n",
+    "# that work together to accurately depict weather conditions\n",
+    "FORECAST_MODEL = \"atmos\"\n",
+    "\n",
+    "folder = f\"gfs.{FORECAST_DATE}/{FORECAST_CYCLE}/{FORECAST_MODEL}/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f17570e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    response = s3.list_objects_v2(Bucket=GFS_BUCKET_NAME, Prefix=folder, Delimiter='/')\n",
+    "\n",
+    "    # Print common prefixes (subfolders)\n",
+    "    if 'CommonPrefixes' in response:\n",
+    "        for prefix in response['CommonPrefixes']:\n",
+    "            print(prefix['Prefix'])\n",
+    "\n",
+    "    # Print object keys\n",
+    "    if 'Contents' in response and response['Contents']:\n",
+    "        for obj in response['Contents']:\n",
+    "            print(obj['Key'])\n",
+    "    else:\n",
+    "        print(\"No objects found in the folder.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Error accessing S3: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c07b5c2",
+   "metadata": {},
+   "source": [
+    "After identifying the required files, the next step is to download them to your local environment. Let's download a single forecast file from the dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4697fcf8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Standard GFS model output in GRIB2 format\n",
+    "# containing a wide range of atmospheric forecast variables at multiple pressure levels and resolutions.\n",
+    "FILE_TYPE = \"pgrb2\"\n",
+    "# Current operational GFS uses a base horizontal resolution of 0.25 degrees (about 28 km between grid points) \n",
+    "# for the first 10 days of the forecast\n",
+    "GRID_RESOLUTION = \"0p25\" \n",
+    "# Number of hours into the future from the model’s initialization time for which a forecast is provided\n",
+    "FORECAST_HOUR = \"017\"\n",
+    "\n",
+    "object_key = f\"gfs.t{FORECAST_CYCLE}z.{FILE_TYPE}.{GRID_RESOLUTION}.f{FORECAST_HOUR}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0cfe396e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remote_object_key = folder+object_key\n",
+    "local_file_name = object_key\n",
+    "s3.download_file(GFS_BUCKET_NAME, remote_object_key, local_file_name)\n",
+    "print(f\"File {object_key} downloaded successfully.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dec88c0a",
+   "metadata": {},
+   "source": [
+    "## 2. Data Inspecting\n",
+    "Open the dataset with xarray, using the `engine='cfgrib'` option to read GRIB files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00d34911",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "\n",
+    "# Vertical coordinate or reference surface for each variable in the dataset.\n",
+    "# The Earth's surface (elevation = 0). Used for variables like surface temperature, precipitation, etc\n",
+    "TYPE_OF_LEVEL = \"surface\"\n",
+    "# Type of time step or time range associated with a forecast variable\n",
+    "STEP_TYPE = \"instant\"\n",
+    "\n",
+    "ds = xr.open_dataset(object_key, engine='cfgrib',\n",
+    "    filter_by_keys={'typeOfLevel': TYPE_OF_LEVEL, 'stepType': STEP_TYPE})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2db10bc4",
+   "metadata": {},
+   "source": [
+    "We can subset our dataset to only include data over Canada."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41844aec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Obtained from https://nominatim.openstreetmap.org/search?q=CA&format=json\n",
+    "lat_min, lat_max = 41.6765597, 83.3362128\n",
+    "lon_min, lon_max = -141.0027500,-52.3237664\n",
+    "\n",
+    "# Adjust longitude range as the dataset uses 0–360 instead of -180–180\n",
+    "if ds.longitude.max() > 180:\n",
+    "    lon_min = (lon_min + 360) % 360\n",
+    "    lon_max = (lon_max + 360) % 360\n",
+    "\n",
+    "canada_ds = ds.sel(latitude=slice(lat_max, lat_min), longitude=slice(lon_min, lon_max))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c35aa865",
+   "metadata": {},
+   "source": [
+    "Let's explore the variables of this dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fccf9dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from IPython.display import display\n",
+    "\n",
+    "variable_rows = []\n",
+    "for variable in canada_ds:\n",
+    "    variable_rows.append({\n",
+    "        \"Variable\": variable,\n",
+    "        \"Long Name\": ds[variable].attrs[\"long_name\"],\n",
+    "        \"Units\": canada_ds[variable].attrs[\"units\"]\n",
+    "    })\n",
+    "\n",
+    "variable_df = pd.DataFrame(variable_rows)\n",
+    "display(variable_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc93ce23",
+   "metadata": {},
+   "source": [
+    "Let's explore the attributes of the `t` (Temperature) variable.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73ce9cea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(canada_ds['t'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db3ff0b5",
+   "metadata": {},
+   "source": [
+    "Let's plot the Wind Speed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e298446e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import plotly.express as px\n",
+    "\n",
+    "wind_df = canada_ds.get([\"gust\"]).to_dataframe()\n",
+    "# Moving latitude and longitude from index to columns\n",
+    "wind_df = wind_df.reset_index()\n",
+    "\n",
+    "fig = px.scatter_geo(\n",
+    "    wind_df,\n",
+    "    lat=\"latitude\",\n",
+    "    lon=\"longitude\",\n",
+    "    color=\"gust\",\n",
+    "    labels={\"gust\": \"Wind Speed\"},\n",
+    "    color_continuous_scale=px.colors.sequential.Viridis\n",
+    ")\n",
+    "fig.update_geos(fitbounds=\"locations\")\n",
+    "fig.update_layout(title=\"Wind Speed in meters per second (m/s)\", title_x=0.5)\n",
+    "fig.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d2bf932",
+   "metadata": {},
+   "source": [
+    "## 3. Data Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "195d70c5",
+   "metadata": {},
+   "source": [
+    "When we explored the attributes of the `t` variable, we noticed that\n",
+    "- Longitudes are expressed in a 0 to 360 degrees range, rather than the standard -180 to 180 degrees\n",
+    "- Unit is Kelvin (K) rather than Celsius (C)\n",
+    "\n",
+    "Let's run transformation on these two attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e37e46d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temperature_df = canada_ds.get([\"t\"]).to_dataframe()\n",
+    "temperature_df = temperature_df.rename(columns={\"t\": \"temperature_kelvin\"})\n",
+    "\n",
+    "# Convert temperature from Kelvin to Celsius\n",
+    "temperature_df[\"temperature_celsius\"] = temperature_df[\"temperature_kelvin\"] - 273.15\n",
+    "\n",
+    "# Move latitude and longitude from index of the dataframe to column\n",
+    "# Convert longitude expressed in a 0 to 360 degrees range to the standard -180 to 180 degrees\n",
+    "temperature_df[\"latitude\"] = temperature_df.index.get_level_values(\"latitude\")\n",
+    "longitude = temperature_df.index.get_level_values(\"longitude\")\n",
+    "standard_longitude = longitude.map(lambda lon: lon - 360 if lon > 180 else lon)\n",
+    "temperature_df[\"longitude\"] = standard_longitude\n",
+    "\n",
+    "# Reset index and select columns\n",
+    "temperature_df = temperature_df.reset_index(drop=True)\n",
+    "temperature_df = temperature_df[[\"time\", \"latitude\", \"longitude\", \"temperature_celsius\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c255989",
+   "metadata": {},
+   "source": [
+    "We can now export the data in Parquet format.  \n",
+    "Storing your preprocessed NOAA GFS data in Parquet format enables\n",
+    "- efficient storage: in the following example we compress the data using `snappy` algorithm\n",
+    "- rapid access to specific data slices: with Parquet, we can read just the required column, minimizing I/O and memory usage\n",
+    "- and seamless scalability for future analyses\n",
+    "\n",
+    "You can quickly reload and analyze just what you need—making your workflow robust, scalable, and ready for advanced analytics or machine learning."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c1b8107",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "temperature_df.to_parquet(\"preprocessed_gfs.parquet\", compression='snappy')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a02e988b",
+   "metadata": {},
+   "source": [
+    "We can load only the specific columns we need from the Parquet file we just wrote"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "814c512b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load only the temperature\n",
+    "global_temperature_df = pd.read_parquet('preprocessed_gfs.parquet', columns=['time', 'temperature_celsius'])\n",
+    "# Run \n",
+    "mean_temp = global_temperature_df.groupby('time')['temperature_celsius'].mean()\n",
+    "print(mean_temp)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
*Description of changes:*
Adding a quickstart notebook for NOAA Global Forecast System (GFS) on RODA.  
This quickstart notebook covers
1. Data Access - how to list and download data from the Registry of Open Data on AWS
2. Data Inspecting - how to inspect the data by printing the variables, etc.
3. Data Preprocessing - convert longitude, temperature from K to °C, etc. Only keep data from a specific area. Export as Parquet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
